### PR TITLE
fix: request connection error handling

### DIFF
--- a/SplunkLambdaCloudWatchLogsProcessor/app.py
+++ b/SplunkLambdaCloudWatchLogsProcessor/app.py
@@ -147,8 +147,8 @@ def lambda_handler(event, context):
             try:
                 r = requests.post(raw_url, headers=authHeader, data=records, verify=verify_ssl, timeout=request_timeout)
             except requests.exceptions.RequestException as e:
-                print("Connection Error")
-                print("HTTP Response Code:",e)
+                print(f"Connection Error: {str(e)}")
+                raise ConnectionError(str(e)) from e
             else:
                 if r.status_code == 200:
                     response = json.loads(r.text)
@@ -171,20 +171,22 @@ def lambda_handler(event, context):
                         print(response)
                 else:
                     print("Connection Error")
-                    print(r)
+                    print("HTTP Response:",r)
+                    raise ConnectionError(f"HTTP Response: {str(r)}")
 
         else:
             try:
                 r = requests.post(raw_url, headers=authHeader, data=records, verify=verify_ssl, timeout=request_timeout)
             except requests.exceptions.RequestException as e:
-                print("Connection Error")
-                print("HTTP Response Code:",e)
+                print(f"Connection Error: {str(e)}")
+                raise ConnectionError(str(e)) from e
             else:
                 if r.status_code == 200:
                     print("Ingestion Success: Without Acknowledgement")
                 else:
                     print("Connection Error")
-                    print(r)
+                    print("HTTP Response:",r)
+                    raise ConnectionError(f"HTTP Response: {str(r)}")
     if os.environ['HEC_ENDPOINT_TYPE'] == 'event':  
         event_url=url+'/event'
         authHeader['X-Splunk-Request-Channel'] = channel   
@@ -206,8 +208,8 @@ def lambda_handler(event, context):
             try:
                 r = requests.post(event_url, headers=authHeader, data=ingest_data, verify=verify_ssl, timeout=request_timeout)
             except requests.exceptions.RequestException as e:
-                print("Connection Error")
-                print("HTTP Response Code:",e)
+                print(f"Connection Error: {str(e)}")
+                raise ConnectionError(str(e)) from e
             else:
                 if r.status_code == 200:
                     response = json.loads(r.text)
@@ -230,20 +232,22 @@ def lambda_handler(event, context):
                         print(response)
                 else:
                     print("Connection Error")
-                    print("HTTP Response Code:",r)
+                    print("HTTP Response:",r)
+                    raise ConnectionError(f"HTTP Response: {str(r)}")
 
         else:
             try:
                 r = requests.post(event_url, headers=authHeader, data=ingest_data, verify=verify_ssl, timeout=request_timeout)
             except requests.exceptions.RequestException as e:
-                print("Connection Error")
-                print("HTTP Response Code:",e)
+                print(f"Connection Error: {str(e)}")
+                raise ConnectionError(str(e)) from e
             else:
                 if r.status_code == 200:
                     print("Ingestion Success: Without Acknowledgement")     
                 else:
                     print("Connection Error")
-                    print("HTTP Response Code:",r)
+                    print("HTTP Response:",r)
+                    raise ConnectionError(f"HTTP Response: {str(r)}")
 
 
 

--- a/SplunkLambdaCloudWatchLogsProcessor/app.py
+++ b/SplunkLambdaCloudWatchLogsProcessor/app.py
@@ -107,16 +107,17 @@ def splunk_ack(url,channel,ack_json,cookies):
             a = requests.post(ack_url, headers=authHeader, json=ack_json, verify=verify_ssl, cookies=cookies, timeout=request_timeout)
         except requests.exceptions.RequestException as e:
             return "Connection Error"
-        if a.status_code != 200:
-            retries +=1 
-            continue
         else:
-            a_response = json.loads(a.text)
-        if a_response['acks'][str(ack_json['acks'][0])] == True:
-            print("Ack Response:",a_response)
-            return True
-        else:
-            retries +=1
+            if a.status_code != 200:
+                retries +=1 
+                continue
+            else:
+                a_response = json.loads(a.text)
+            if a_response['acks'][str(ack_json['acks'][0])] == True:
+                print("Ack Response:",a_response)
+                return True
+            else:
+                retries +=1
     if retries >= ack_retries:
         # Troubleshooting
         if os.environ['DEBUG_DATA'].lower() == "true":
@@ -148,28 +149,29 @@ def lambda_handler(event, context):
             except requests.exceptions.RequestException as e:
                 print("Connection Error")
                 print("HTTP Response Code:",e)
-            if r.status_code == 200:
-                response = json.loads(r.text)
-                if response['text'] == 'Success':
-                    ack_json = {"acks":[response['ackId']]}
-                    # Check if ELB Cookies are set
-                    if len(cookie_name.strip()) > 0:
-                        cookies = {cookie_name: (r.headers['Set-Cookie'].split(";")[0]).split("=")[1]}
-                        print("response cookie",cookies)
-                    else:
-                        cookies = ""                        
-                    time.sleep(ack_wait_secs)
-                    ack = splunk_ack(url,channel,ack_json,cookies)                                                    
-                    if ack:
-                        print("Ingestion Success: With Acknowledgement")
-                    else:
-                        print("Acknowledgement Failed")                                
-                if response['text'] != 'Success':
-                    print("Ingestion failed")
-                    print(response)
             else:
-                print("Connection Error")
-                print(r)
+                if r.status_code == 200:
+                    response = json.loads(r.text)
+                    if response['text'] == 'Success':
+                        ack_json = {"acks":[response['ackId']]}
+                        # Check if ELB Cookies are set
+                        if len(cookie_name.strip()) > 0:
+                            cookies = {cookie_name: (r.headers['Set-Cookie'].split(";")[0]).split("=")[1]}
+                            print("response cookie",cookies)
+                        else:
+                            cookies = ""                        
+                        time.sleep(ack_wait_secs)
+                        ack = splunk_ack(url,channel,ack_json,cookies)                                                    
+                        if ack:
+                            print("Ingestion Success: With Acknowledgement")
+                        else:
+                            print("Acknowledgement Failed")                                
+                    if response['text'] != 'Success':
+                        print("Ingestion failed")
+                        print(response)
+                else:
+                    print("Connection Error")
+                    print(r)
 
         else:
             try:
@@ -177,11 +179,12 @@ def lambda_handler(event, context):
             except requests.exceptions.RequestException as e:
                 print("Connection Error")
                 print("HTTP Response Code:",e)
-            if r.status_code == 200:
-               print("Ingestion Success: Without Acknowledgement")     
             else:
-                print("Connection Error")
-                print(r)
+                if r.status_code == 200:
+                    print("Ingestion Success: Without Acknowledgement")
+                else:
+                    print("Connection Error")
+                    print(r)
     if os.environ['HEC_ENDPOINT_TYPE'] == 'event':  
         event_url=url+'/event'
         authHeader['X-Splunk-Request-Channel'] = channel   
@@ -205,28 +208,29 @@ def lambda_handler(event, context):
             except requests.exceptions.RequestException as e:
                 print("Connection Error")
                 print("HTTP Response Code:",e)
-            if r.status_code == 200:
-                response = json.loads(r.text)
-                if response['text'] == 'Success':
-                    ack_json = {"acks":[response['ackId']]}
-                    # Check if ELB Cookies are set
-                    if len(cookie_name.strip()) > 0:
-                        cookies = {cookie_name: (r.headers['Set-Cookie'].split(";")[0]).split("=")[1]}
-                        print("response cookie",cookies)
-                    else:
-                        cookies = ""                        
-                    time.sleep(ack_wait_secs)
-                    ack = splunk_ack(url,channel,ack_json,cookies)                                                    
-                    if ack:
-                        print("Ingestion Success: With Acknowledgement")
-                    else:
-                        print("Acknowledge Failed")                                
-                if response['text'] != 'Success':
-                    print("Ingestion failed")
-                    print(response)
             else:
-                print("Connection Error")
-                print("HTTP Response Code:",r)
+                if r.status_code == 200:
+                    response = json.loads(r.text)
+                    if response['text'] == 'Success':
+                        ack_json = {"acks":[response['ackId']]}
+                        # Check if ELB Cookies are set
+                        if len(cookie_name.strip()) > 0:
+                            cookies = {cookie_name: (r.headers['Set-Cookie'].split(";")[0]).split("=")[1]}
+                            print("response cookie",cookies)
+                        else:
+                            cookies = ""                        
+                        time.sleep(ack_wait_secs)
+                        ack = splunk_ack(url,channel,ack_json,cookies)                                                    
+                        if ack:
+                            print("Ingestion Success: With Acknowledgement")
+                        else:
+                            print("Acknowledge Failed")                                
+                    if response['text'] != 'Success':
+                        print("Ingestion failed")
+                        print(response)
+                else:
+                    print("Connection Error")
+                    print("HTTP Response Code:",r)
 
         else:
             try:
@@ -234,11 +238,12 @@ def lambda_handler(event, context):
             except requests.exceptions.RequestException as e:
                 print("Connection Error")
                 print("HTTP Response Code:",e)
-            if r.status_code == 200:
-               print("Ingestion Success: Without Acknowledgement")     
             else:
-                print("Connection Error")
-                print("HTTP Response Code:",r)
+                if r.status_code == 200:
+                    print("Ingestion Success: Without Acknowledgement")     
+                else:
+                    print("Connection Error")
+                    print("HTTP Response Code:",r)
 
 
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* 
Ran into errors with "r" being accessed before assignment when encountering a RequestException

- try..except..else blocks: added an "else" block to the connection try..except blocks; moved lines accessing the connection response "r" into the else blocks
- raise fatal connection errors: for fatal RequestException exceptions, raised ConnectionError to kill the script, so lambda marks the run as failed, and to print the exception to the lambda output tab
- splunk_ack() fixes:
  - changed return of "Connection Error" string (which would originally evaluate as a success) to print() and return False.
  - changed evaluation of function results from truthiness to truth
  - removed unnecessary conditional for troubleshooting section (will run if while block exits without a return)
  - local vs global variable deconfliction


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
